### PR TITLE
Use keypress instead of keyup in bindEnterAndEscape

### DIFF
--- a/etherpad/src/static/js/pad_utils.js
+++ b/etherpad/src/static/js/pad_utils.js
@@ -154,6 +154,12 @@ var padutils = {
     return pieces.join('');
   },
   bindEnterAndEscape: function(node, onEnter, onEscape) {
+
+    // Use keypress instead of keyup in bindEnterAndEscape
+    // Keyup event is fired on enter in IME (Input Method Editor), But
+    // keypress is not. So, I changed to use keypress instead of keyup.
+    // It is work on Windows (IE8, Chrome 6.0.472), CentOs (Firefox 3.0) and Mac OSX (Firefox 3.6.10, Chrome 6.0.472, Safari 5.0).
+    
     if (onEnter) {
       node.keypress( function(evt) {
         if (evt.which == 13) {

--- a/etherpad/src/static/js/pad_utils.js
+++ b/etherpad/src/static/js/pad_utils.js
@@ -154,23 +154,21 @@ var padutils = {
     return pieces.join('');
   },
   bindEnterAndEscape: function(node, onEnter, onEscape) {
-    function handleKey(evt) {
-      if (evt.which == 27 && onEscape) {
-        // "escape" key
-        if (evt.type == 'keydown') {
-          onEscape(evt);
-        }
-        evt.preventDefault();
-      }
-      else if (evt.which == 13 && onEnter) {
-        // return/enter
-        if (evt.type == 'keyup') {
+    if (onEnter) {
+      node.keypress( function(evt) {
+        if (evt.which == 13) {
           onEnter(evt);
         }
-        evt.preventDefault();
-      }
+      });
     }
-    $(node).bind('keyup keypress keydown', handleKey);
+
+    if (onEscape) {
+      node.keydown( function(evt) {
+        if (evt.which == 27) {
+          onEscape(evt);
+        }
+      });
+    }
   },
   timediff: function(d) {
     function format(n, word) {


### PR DESCRIPTION
Hi. 
etherpad is very useful things, but I found a problem of IME (Input Method Editor). When press enter in IME, keyup event is fired and text is sent in chat window. It is critical problem for IME users. So I changed to use keypress instead of keyup. Keypress event is not fired in it.
Thanks.

Soh Kitahara
