### PR TITLE
A status page for the users when the Etherpad instance isn't behaving

### DIFF
--- a/contrib/50x-error-handler/50x.html
+++ b/contrib/50x-error-handler/50x.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+            "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<title>This Etherpad instance is having some difficulties at the moment</title>
+
+<script type="text/javascript">
+var reload_page_after = (30 + (parseInt(Math.random() * 90)));
+var reload = false;
+function update_restart_in()
+{
+	var el = document.getElementById('restart-in');
+	var now = new Date;
+	now = parseInt(now.valueOf() / 1000);
+	// How much time has passed since the watcher script last could connect?
+	var since = now - last_updated;
+	// A script check if piratepad.net is accessible every 3 minutes.
+	// The timeout is 8 minutes so the restart is 60 seconds after the timeout.
+	var diff = (timeout + 60) - since;
+
+
+	var update = diff;
+	if(Math.abs(diff) > 60)
+	{
+		update = talky_time(diff);
+	}
+
+	el.innerHTML = update;
+	// If piratepad should've been restarted start the timer to reload this page!
+	if(diff <= 0 && reload == false)
+	{
+		reload = true;
+		window.setTimeout("window.location.reload()", reload_page_after * 1000);
+	}
+
+	window.setTimeout(update_restart_in, 1000);
+}
+
+function set_reload_time(val)
+{
+	document.getElementById('reload-time').innerHTML = talky_time(val);
+}
+
+function talky_time(seconds)
+{
+	var sec = seconds % 60;
+	var mins = (seconds - sec) / 60;
+	if(mins > 0 && !(mins == 1 && sec == 0))
+		return mins + " minute" + ((mins > 1) ? "s" : "") + " and " + sec;
+	else
+		return seconds;
+}
+</script>
+<script type="text/javascript" src="last-updated.js"></script>
+</head>
+<body onLoad="set_reload_time(reload_page_after); update_restart_in();">
+<div>
+	<p>
+		This Etherpad instance is having some difficulties at the moment, but should be back on track soon!<br>
+		Please try again or wait for the timeout below.
+	</p>
+	<p>
+		An automatic restart of Etherpad will occur in <span id="restart-in">UNKNOWN</span> seconds.<br>
+		This page will automatically reload <span id="reload-time">A RANDOM NUMBER OF</span> seconds after Etherpad should've been restarted.
+	</p>
+</div>
+</body>
+</html>

--- a/contrib/apache.conf
+++ b/contrib/apache.conf
@@ -3,7 +3,6 @@
         AddDefaultCharset utf-8
         ServerAdmin support@etherpad.org
         ServerName etherpad.org
-        DocumentRoot /srv/www/etherpad.org/html
         Options ExecCgi Includes MultiViews Indexes FollowSymlinks
         ErrorLog /var/log/apache2/etherpad.org-error_log
         TransferLog /var/log/apache2/etherpad.org-access_log
@@ -15,5 +14,17 @@
 	Alias /sitemap.xml /ep/tag/\?format=sitemap
 	ProxyPreserveHost On
         ProxyPass / http://localhost:9001/
+
+	###
+	# A little html+javascript to show the current status of Etherpad
+	# when it can't be accessed because of a 50x error. 
+	# Source html in etherpad/data/50x-error-handler/50x.html
+	# Uncomment to activate, requires the use of contrib/bin/etherpad-watcher.sh
+	#ErrorDocument 500 /50x.html
+	#ErrorDocument 502 /50x.html
+	#ErrorDocument 503 /50x.html
+	#ErrorDocument 504 /50x.html
+	#Alias /50x.html        /opt/etherpad/etherpad/data/50x-error-handler/50x.html
+	#Alias /last-updated.js /opt/etherpad/etherpad/data/50x-error-handler/last-updated.js
 
 </VirtualHost>

--- a/contrib/bin/etherpad-watcher.sh
+++ b/contrib/bin/etherpad-watcher.sh
@@ -1,21 +1,44 @@
 #!/bin/bash
-# requires bash 3
+# This script requires bash 3 and curl to work
 
-URL=http://etherpad-site.tld/ep/admin/auth
+# This script will check if your Etherpad instance is up and running.
+# If all is well it will touch a file to keep track of when all was last OK,
+# as well as also tagging that time in a Javascript source file to be used with
+# the error-handler in contrib/50x-error-handler.
+#
+# The error-handler is a simple countdown to the automatic restart set by
+# this script and will also automatically reload the page for the user at a
+# random intervall after the Etherpad instance should've been restarted.
+# Example directives for apache and nginx in contrib/
+# Also remember to copy the HTML-file in contrib/50x-error-handler
+
+# Remember to set the URL to the URL you want to use to check if Etherpad is up
+URL=http://etherpad.your-domain.tld/ep/admin/auth
 EXPECTED_CODE=200
 TEST_FILE=/tmp/pad-watcher
-TIMEOUT=480 # 5 minutes
+TIMEOUT=480 # 8 minutes
 RESTART_COMMAND='/opt/etherpad/bin/restart.sh &'
+LAST_UPDATED_JS='/opt/etherpad/etherpad/data/50x-error-handler/last-updated.js'
+
+
+###
+# This is used for an error-handler for gateway errors
+# If set correctly at your proxy server a seconds since last working connect
+# and a timer for automatic restart will be shown.
+function set_last_updated {
+    echo "var last_updated = `date +%s`;" > $LAST_UPDATED_JS
+    echo "var timeout = ${TIMEOUT};" >> $LAST_UPDATED_JS
+}
 
 ###
 # Actual test
 #
 # If it has been longer than TIMEOUT seconds 
 # since TEST_FILE was touched RESTART_COMMAND is run.
-
 test=`/usr/bin/curl -m 60 -s -S -I ${URL} | grep '^HTTP'`
 if [[ "${test}" =~ "${EXPECTED_CODE}" ]] ; then
     touch $TEST_FILE
+    set_last_updated
 else
     if [[ -f $TEST_FILE ]] ; then
         NOW=`date +%s` # Seconds since epoch
@@ -30,5 +53,6 @@ else
         fi
     else
         touch $TEST_FILE
+        set_last_updated
     fi
 fi

--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -25,5 +25,16 @@ server {
  location / {
  proxy_pass http://localhost:9000/;
  }
+
+ ###
+ # A little html+javascript to show the current status of Etherpad
+ # when it can't be accessed because of a 50x error. 
+ # Source html in etherpad/data/50x-error-handler/50x.html
+ # Uncomment to activate, requires the use of contrib/bin/etherpad-watcher.sh
+# error_page 500 502 503 504 /50x.html;
+# location ~ ^/(50x.html|last-updated.js)$ {
+#   root /opt/piratepad/etherpad/data/50x-error-handler;
+# }
+
 }
 


### PR DESCRIPTION
This commit adds a status page for when the Etherpad instance should be automatically restarted by the contrib/bin/etherpad-watcher.sh script.

The status page is an error handler that you just need to setup with your HTTP gateway, the included configs for apache and nginx has been updated.

The contrib/bin/etherpad-watcher.sh script will write out the last successful connection to a javascript-file that the error-handler will include and use to calculate a restart time.

This has all been deployed to Piratepad.net and is working well.
