### PR TITLE
Made UTF-8 the default charset on responses from Etherpad

### DIFF
--- a/infrastructure/framework-src/modules/faststatic.js
+++ b/infrastructure/framework-src/modules/faststatic.js
@@ -46,7 +46,7 @@ var _contentTypes = {
   'jpg': 'image/jpeg',
   'jpeg': 'image/jpeg',
   'css': 'text/css',
-  'js': 'application/x-javascript; charset=utf-8',
+  'js': 'application/x-javascript',
   'txt': 'text/plain; charset=utf-8',
   'html': 'text/html; charset=utf-8',
   'ico': 'image/x-icon',

--- a/infrastructure/framework-src/modules/faststatic.js
+++ b/infrastructure/framework-src/modules/faststatic.js
@@ -46,8 +46,8 @@ var _contentTypes = {
   'jpg': 'image/jpeg',
   'jpeg': 'image/jpeg',
   'css': 'text/css',
-  'js': 'application/x-javascript',
-  'txt': 'text/plain',
+  'js': 'application/x-javascript; charset=utf-8',
+  'txt': 'text/plain; charset=utf-8',
   'html': 'text/html; charset=utf-8',
   'ico': 'image/x-icon',
   'swf': 'application/x-shockwave-flash',
@@ -63,7 +63,7 @@ var _gzipableTypes = {
 
 function _guessContentType(path) {
   var ext = path.split('.').pop().toLowerCase();
-  return _contentTypes[ext] || 'text/plain';
+  return _contentTypes[ext] || _contentTypes['txt'];
 }
 
 //----------------------------------------------------------------

--- a/infrastructure/net.appjet.ajstdlib/ajstdlib.scala
+++ b/infrastructure/net.appjet.ajstdlib/ajstdlib.scala
@@ -241,7 +241,7 @@ object email {
           }
 
         msg.setSubject(subject);
-        msg.setContent(content, "text/plain");
+        msg.setContent(content, "text/plain; charset=utf-8");
         Transport.send(msg);
         "";
       }

--- a/infrastructure/net.appjet.ajstdlib/streaming.scala
+++ b/infrastructure/net.appjet.ajstdlib/streaming.scala
@@ -540,7 +540,7 @@ var d = parent.comet.disconnect;"""+(if(!config.devMode)"\nwindow.onerror = func
   
   override def handleNewConnection(req: HttpServletRequest, res: HttpServletResponse, out: StringBuilder) {
     super.handleNewConnection(req, res, out);
-    res.setContentType("text/html");
+    res.setContentType("text/html; charset=utf-8");
     out.append(header(req));
   }
 }

--- a/infrastructure/net.appjet.oui/execution.scala
+++ b/infrastructure/net.appjet.oui/execution.scala
@@ -166,7 +166,7 @@ class ResponseWrapper(val res: HttpServletResponse) {
   private lazy val outputStrings = new ListBuffer[String];
   private lazy val outputBytes = new ListBuffer[Array[byte]];
   private var statusCode = 200;
-  private var contentType = "text/html";
+  private var contentType = "text/html; charset=utf-8";
   private var redirect: String = null;
   private lazy val headers = new LinkedHashSet[(String, String, HttpServletResponse => Unit)] {
     def removeAll(k: String) {


### PR DESCRIPTION
Piratepad.net had problems viewing UTF-8 glyphs on some browser combinations, tracked down that the problem occured when Etherpad is behind a proxy and the charset wasn't set on the response.

Piratepad is running behind a nginx that caches some requests and I havn't spent any time figuring out WHY this happens since I felt that the default should be send in UTF-8 in any case.
