### PR TITLE
When useHttpsUrl is on, etherpad should masquerade an incoming HTTP connection as if it was using HTTPS

### DIFF
--- a/etherpad/src/etherpad/control/aboutcontrol.js
+++ b/etherpad/src/etherpad/control/aboutcontrol.js
@@ -181,7 +181,7 @@ function render_eepnet_pricing_contact_post() {
     '00N80000003FYuI': googleQuery,
     lead_source: 'EEPNET Pricing Inquiry',
     industry: data.industry,
-    retURL: 'http://'+request.host+'/ep/store/salesforce-web2lead-ok'
+    retURL: request.scheme+'://'+request.host+'/ep/store/salesforce-web2lead-ok'
   };
 
   var result = netutils.urlPost(

--- a/etherpad/src/etherpad/control/pro_signup_control.js
+++ b/etherpad/src/etherpad/control/pro_signup_control.js
@@ -163,7 +163,7 @@ function render_main_post() {
   });
 
   if (ok) {
-    response.redirect('http://'+subdomain+"."+request.host+'/ep/finish-activation');
+    response.redirect(request.scheme+"://"+subdomain+"."+request.host+'/ep/finish-activation');
   } else {
     response.write("There was an error processing your request.");
   }

--- a/infrastructure/framework-src/modules/global/request.js
+++ b/infrastructure/framework-src/modules/global/request.js
@@ -144,7 +144,7 @@ get isPost() {
  */
 get scheme() {
   if (this.isDefined) {
-    return String(_cx().request().scheme());
+    return appjet.config.useHttpsUrls ? "https" : String(_cx().request().scheme());
   }
 },
 


### PR DESCRIPTION
When useHttpsUrl is on, etherpad should masquerade an incoming HTTP connection as if it was using HTTPS. This allows setups where a reverse proxy (aka Apache / nginx) is handling SSL deciphering.

In this commit, I simply added support to this in request.js. This is _nearly_ enough to make everything works, except that http:// is still hardcoded in two places.

Damien
