### PR TITLE
WebKit crash fix

### DIFF
--- a/etherpad/src/static/js/pad_userlist.js
+++ b/etherpad/src/static/js/pad_userlist.js
@@ -111,7 +111,8 @@ var paduserlist = (function() {
     }
     function handleRowNode(tr, data) {
       if (data.titleText) {
-        tr.attr('title', data.titleText);
+        var titleText = data.titleText;
+        window.setTimeout(function() { tr.attr('title', titleText )}, 0);
       }
       else {
         tr.removeAttr('title');


### PR DESCRIPTION
This change fixes the issue described here: http://groups.google.com/group/etherpad-dev/browse_thread/thread/726fef0e91d52331

I'd love to see this get propagated everywhere, so I can start using etherpad clones with Safari again!!
