### PR TITLE
Readonly-Plugin

### DIFF
--- a/etherpad/src/etherpad/collab/collab_server.js
+++ b/etherpad/src/etherpad/collab/collab_server.js
@@ -30,6 +30,7 @@ import("fileutils.readFile");
 import("jsutils.{eachProperty,keys}");
 import("etherpad.collab.collabroom_server.*");
 import("etherpad.collab.readonly_server");
+import("etherpad.admin.plugins");
 jimport("java.util.concurrent.ConcurrentHashMap");
 
 var PADPAGE_ROOMTYPE = "padpage";
@@ -687,6 +688,22 @@ function _handleCometMessage(connection, msg) {
 
   if (msg.type == "USER_CHANGES") {
     try {
+	
+	var plugin_checks = plugins.callHook("collabServerUserChanges", {pad: _roomToPadId(connection.roomName), msg: msg});
+        var plugin_access=true;
+
+        plugin_checks.forEach(function(value) {
+            if(value==false)
+            {
+                plugin_access=false;
+            }
+        });
+
+        if(!plugin_access)
+        {
+            return false;
+        }
+    
       _accessConnectionPad(connection, "USER_CHANGES", function(pad) {
         var baseRev = msg.baseRev;
         var wireApool = (new AttribPool()).fromJsonable(msg.apool);

--- a/etherpad/src/plugins/readonlyPad/hooks.js
+++ b/etherpad/src/plugins/readonlyPad/hooks.js
@@ -1,0 +1,43 @@
+import("etherpad.log");
+import("faststatic");
+import("etherpad.utils.*");
+import("etherpad.globals.*");
+import("etherpad.helpers");
+import("dispatch.{Dispatcher,PrefixMatcher,forward}");
+import("sqlbase.sqlobj");
+import("etherpad.pad.model");
+import("etherpad.pro.pro_accounts");
+import("fastJSON");
+
+
+var readonlyPad_data = [];
+
+function docBarDropdownsPad(arg) {
+    helpers.includeCss('plugins/readonlyPad/readonlyPad.css');
+    helpers.includeJs('plugins/readonlyPad/readonlyPad.js');
+    
+    return arg.template.include('readonlyPadDropdown.ejs', undefined, ['readonlyPad']);
+}
+
+function collabServerUserChanges(args) {
+    var readonlyPad_return = true;
+    model.accessPadGlobal(args.pad, function(pad) {
+	var opts = pad.getPadOptionsObj();
+	
+	if(opts.view)
+	{
+	    var isReadOnly = opts.view.readonlyPadPolicy;
+	    if(isReadOnly!=null)
+	    {
+		if(isReadOnly==true)
+		{
+		    if(!pro_accounts.isAccountSignedIn())
+		    {
+			readonlyPad_return = false;
+		    }
+		}
+	    }
+	}
+    });
+    return [readonlyPad_return];
+}

--- a/etherpad/src/plugins/readonlyPad/main.js
+++ b/etherpad/src/plugins/readonlyPad/main.js
@@ -1,0 +1,21 @@
+import("etherpad.log");
+import("plugins.readonlyPad.hooks");
+import("sqlbase.sqlobj");
+
+function readonlyPadInit() {
+    this.hooks = ['docBarDropdownsPad', 'collabServerUserChanges'];
+    this.description = 'With this plugin you can set a public pad to readonly for guests';
+    this.docBarDropdownsPad = hooks.docBarDropdownsPad;
+    this.collabServerUserChanges = hooks.collabServerUserChanges;
+    this.install = install;
+    this.uninstall = uninstall;
+}
+
+function install() {
+    log.info("Installing readonlyPad");
+}
+
+function uninstall() {
+    log.info("Uninstalling readonlyPad");
+}
+

--- a/etherpad/src/plugins/readonlyPad/static/css/readonlyPad.css
+++ b/etherpad/src/plugins/readonlyPad/static/css/readonlyPad.css
@@ -1,0 +1,26 @@
+div.readonlyPadHidden {
+    display: none;
+}
+
+div#readonlyPad {
+    position: absolute;
+    left: 15px;
+}
+
+div#readonlyPad strong {
+    font-weight: normal;
+    padding-right: 10px;
+    color: #444444;
+}
+
+div#readonlyPad input {
+    position: absolute;
+    left: 10px;
+}
+
+div#readonlyPad label {
+    position: absolute;
+    left: 30px;
+    width: 260px;
+    color: #999999;
+}

--- a/etherpad/src/plugins/readonlyPad/static/js/readonlyPad.js
+++ b/etherpad/src/plugins/readonlyPad/static/js/readonlyPad.js
@@ -1,0 +1,133 @@
+padeditor.enable = function()
+{
+    if (padeditor.ace)
+    {
+	padeditor.ace.setProperty("grayedOut", false);
+        padeditor.ace.setEditable(true);
+    }
+}
+
+function readonlyPad_moveTop(start, height)
+{
+    var el = start;
+    var el_pos;
+    
+    do {
+	if(el.length==0)
+	{
+	    return;
+	}
+    
+	if(el[0] && el[0].nodeName && el[0].nodeName.toLowerCase()=='div')
+	{
+	    if(el.children().length>0)
+	    {
+		readonlyPad_moveTop(el.children().eq(0), height);
+	    }
+	}
+	
+	el_pos = el.position();
+	if(el_pos && el_pos.top>0)
+	{
+	    el.css('top', el_pos.top + height + 'px');
+	}
+    } while(el = el.next());
+}
+
+function readonlyPad_adminInit()
+{
+    var div = $('div#readonlyPad');
+    var access = $('div#security-access');
+    
+    if(div.length>1)
+    {
+	var el = div.eq(0);
+	while((el = el.next()) && el.length>0)
+	{
+	    el.remove();
+	}
+    }
+    
+    access.after(div);
+    var access_private_pos = $('#access-private-label').position();
+    var access_public_pos  = $('#access-public-label').position();
+    
+    var height = (access_public_pos.top - access_private_pos.top);
+    
+    div.css('top', (access_public_pos.top + height) + 'px');
+    div.removeClass('readonlyPadHidden');
+    
+    readonlyPad_moveTop(div.next(), height);
+    
+    $('#security-panel').css('height', $('#security-panel').height() + height);
+    
+    if(clientVars.initialOptions && clientVars.initialOptions.view && clientVars.initialOptions.view.readonlyPadPolicy)
+    {
+	$('#readonlyPadCheckbox')[0].checked = true;
+    }
+    
+    $('#readonlyPadCheckbox').bind('change click', function(evt) {
+	pad.changeViewOption('readonlyPadPolicy', $('#readonlyPadCheckbox')[0].checked)
+    });
+}
+
+function readonlyPad_guestInit()
+{
+    if(clientVars.initialOptions && clientVars.initialOptions.view && clientVars.initialOptions.view.readonlyPadPolicy)
+    {
+	padeditor.disable();
+    }
+}
+
+function readonlyPad_handleOptionsChange(opts)
+{
+    if(opts && opts.view && opts.view.readonlyPadPolicy!=null)
+    {
+	if(clientVars["userIsGuest"]==true)
+	{
+	    if(opts.view.readonlyPadPolicy==true)
+	    {
+		padeditor.disable();
+	    }
+	    else
+	    {
+		padeditor.enable();
+	    }
+	}
+	else
+	{
+	    $('#readonlyPadCheckbox')[0].checked = opts.view.readonlyPadPolicy;
+	}
+    }
+}
+
+
+function readonlyPad_handleInit()
+{
+    var old = pad.handleOptionsChange;
+    
+    pad.handleOptionsChange = function(opts)
+    {
+	old(opts);
+	readonlyPad_handleOptionsChange(opts);
+    }
+    
+    
+}
+
+$(document).ready(function ()
+{
+
+    if(clientVars["isProPad"]==true)
+    
+    if(clientVars["userIsGuest"]==true)
+    {
+	readonlyPad_guestInit();
+    }
+    else
+    {
+	readonlyPad_adminInit();
+    }
+    
+    readonlyPad_handleInit();
+});

--- a/etherpad/src/plugins/readonlyPad/templates/readonlyPadDropdown.ejs
+++ b/etherpad/src/plugins/readonlyPad/templates/readonlyPadDropdown.ejs
@@ -1,0 +1,4 @@
+<div id="readonlyPad" class="readonlyPadHidden">
+    <input type="checkbox" name="readonlyPad" id="readonlyPadCheckbox" value="readonly"/>
+    <label for="readonlyPad" id="readonlyPad-label"><strong>Public-Readonly</strong> (Readonly for guests)</label>
+</div>

--- a/etherpad/src/plugins/readonlyPad/templates/readonlyPadEditbarButtons.ejs
+++ b/etherpad/src/plugins/readonlyPad/templates/readonlyPadEditbarButtons.ejs
@@ -1,0 +1,24 @@
+<%
+  if (request.path.indexOf('/ep/pad/view') >= 0) {
+    padId = request.path.split('/ep/pad/view/', 2)[1].split('/rev.', 2);
+    padRev = padId[1];
+    padId = padId[0];
+  } else {
+    padRev = 'latest';
+    padId = request.path.split("/")[1];
+  }
+  params = ["old=" + padId];
+  if (padRev != 'latest')
+    params.push("old_rev=" + padRev);
+  params = params.join('&');
+%>
+<td>&nbsp;&nbsp;</td>
+<td><img src="/static/img/jun09/pad/editbar_groupleft.gif" width="2" height="24"></td>
+<td class="editbarbutton editbargroupsfirst">
+  <a href="/ep/readonlyPad?<%= params %>" title="Copy pad"><img src="/static/html/plugins/copyPad/editbar_copy.gif"></a>
+</td>
+<td class="editbarbutton">
+  <a href="/ep/search?linksto=<%= padId %>" title="Find links to this pad (including copies of this pad)"><img src="/static/html/plugins/copyPad/editbar_find_links.gif"></a>
+</td>
+<td><img src="/static/img/jun09/pad/editbar_groupright.gif" width="2" height="24"></td>
+<td>&nbsp;&nbsp;</td>

--- a/infrastructure/ace/www/ace2_inner.js
+++ b/infrastructure/ace/www/ace2_inner.js
@@ -1016,7 +1016,7 @@ function OUTER(gscope) {
     //if (! top.BEFORE) top.BEFORE = [];
     //top.BEFORE.push(magicdom.root.dom.innerHTML);
 
-    if (! isEditable) return; // and don't reschedule
+    //if (! isEditable) return; // and don't reschedule
 
     if (inInternationalComposition) {
       // don't do idle input incorporation during international input composition


### PR DESCRIPTION
This commit integrates a plugin for a new readonly feature.

You can set a public pro pad to "readonly" so guest users cannot change the pad text anoymore (different than logged in users).

It is mainly a plugin, but I needed to change two files:
- infrastructure/ace/www/ace2_inner.js : without this change the line numbers wouldn't be updatet in readonly mode
- etherpad/src/etherpad/collab/collab_server.js : just a new small hook, that allows plugins to deny write access to the pad text
