### PR TITLE
Correct two admin related crashes and a display problem with the twitterStyleTags plugin

### DIFF
--- a/etherpad/src/etherpad/control/admincontrol.js
+++ b/etherpad/src/etherpad/control/admincontrol.js
@@ -533,7 +533,7 @@ function render_padinspector_get() {
       config: appjet.config,
       bodyClass: 'nonpropad',
       title: 'Pad inspector',
-      content: DIV(body, script)
+      content: DIV(div, script)
      });
   }, "r");
 }

--- a/etherpad/src/etherpad/pro/pro_accounts.js
+++ b/etherpad/src/etherpad/pro/pro_accounts.js
@@ -560,14 +560,24 @@ function getAllAccountsWithEmail(email) {
 }
 
 function getEtherpadAdminAccount() {
+  try {
+    return {
+      id: 0,
+      isAdmin: true,
+      fullName: "ETHERPAD ADMIN",
+      email: "support@etherpad.com",
+      domainId: domains.getRequestDomainId(),
+      isDeleted: false
+    };
+  } catch (e) {}
   return {
     id: 0,
     isAdmin: true,
     fullName: "ETHERPAD ADMIN",
     email: "support@etherpad.com",
-    domainId: domains.getRequestDomainId(),
+    domainId: undefined,
     isDeleted: false
-  };
+  }
 }
 
 function getCachedActiveCount(domainId) {

--- a/etherpad/src/plugins/twitterStyleTags/templates/tagBrowser.ejs
+++ b/etherpad/src/plugins/twitterStyleTags/templates/tagBrowser.ejs
@@ -35,8 +35,7 @@ limitations under the License. */ %>
        var matchingPadId = matchingPads[i].ID;
        var matchingPadUrl = matchingPadId;
        if (!inArray('writable', matchingPads[i].TAGS)) {
-	 matchingPadId = padIdToReadonly(matchingPads[i].ID);
-	 matchingPadUrl = 'ep/pad/view/' + matchingPadId + '/latest';
+	 matchingPadUrl = 'ep/pad/view/' + padIdToReadonly(matchingPadId) + '/latest';
        } else if (padutils.isProPadId(matchingPadId)) {
          matchingPadId = padutils.globalToLocalId(matchingPadId);
 	 matchingPadUrl = matchingPadId;


### PR DESCRIPTION
Fixes:"body" ReferenceError in the admin console
https://github.com/ether/pad/issues/issue/222

Fixes: admin pad snoop on non-pro pads throws domainId exception
https://github.com/ether/pad/issues/issue/223

Fixes: pad names aren't displayed correctly in the twitterStyleTags plugin
https://github.com/ether/pad/issues/issue/224
