### PR TITLE
This seems to be to be a bad commit. 

### DIFF
--- a/debian/etherpad.init
+++ b/debian/etherpad.init
@@ -47,7 +47,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Collaborative real-time editor"
 NAME="etherpad"
-DAEMON_BASE="/usr/local/etherpad"
+DAEMON_BASE="/usr/share/etherpad"
 DAEMON=$DAEMON_BASE/bin/run.sh
 DAEMON_ARGS=""
 PIDFILE=/var/run/$NAME.pid


### PR DESCRIPTION
Revert "Changed init script to match correct path"

The debian package should refer to /usr/share, not /usr/local

This reverts commit 0c7ba5176748628ae0e7c5f3ea17d865c618e19c.
