### PR TITLE
Debian packaging suggestion: Don't overwrite /etc/etherpad/etherpad.local.properties if it already exists.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -5,18 +5,18 @@
 # Copyright (c) 2010 penSec.IT UG (haftungsbeschränkt)
 #        http://www.pensec.it
 #        mail@pensec.it
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
-# 
+#
 #        http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
-# the License. 
+# the License.
 #
 ################################################################################
 
@@ -32,7 +32,7 @@ fi
 
 db_version 2.0
 
-. /usr/share/dbconfig-common/dpkg/postinst.mysql 
+. /usr/share/dbconfig-common/dpkg/postinst.mysql
 dbc_go etherpad $@
 
 db_get "etherpad/admin_password"
@@ -66,7 +66,9 @@ if ! [ "$dbc_dbport" ]; then
   dbc_dbport=3306
 fi
 
-
+if [ -f /etc/etherpad/etherpad.local.properties ]; then
+    echo "/etc/etherpad/etherpad.local.properties already exists, no changes done"
+else
 m4 \
  -D __db_admin_password__="$db_admin_password" \
  -D __dbc_dbserver__="$dbc_dbserver" \
@@ -77,6 +79,7 @@ m4 \
  -D __db_topdomains__="$db_topdomains" \
  < /etc/etherpad/etherpad.local.properties.tmpl \
  > /etc/etherpad/etherpad.local.properties
+fi
 
 chown etherpad:etherpad /etc/etherpad/etherpad.local.properties
 


### PR DESCRIPTION
This patch just skips writing a new /etc/etherpad/etherpad.local.properties if it already exists.

This is not an ideal solution, someone with better knowledge about that whole dpkg-thing can probably make this work with an configuration overwrite prompt or something like that.

I still belive that this is better than destroying current config.
