### PR TITLE
fixed missing '[[' when dash is the default shell

### DIFF
--- a/infrastructure/ace/bin/make
+++ b/infrastructure/ace/bin/make
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 mkdir -p ../../etherpad/src/etherpad/collab/ace
 mkdir -p ../../etherpad/src/static/js
 


### PR DESCRIPTION
When /bin/sh is linked to /bin/dash (seems to be the default on Debian 6), bin/make says:

```
bin/make: 11: [[: not found
```
