### PR TITLE
pad_control.js change to fix a bug found in my instance of Etherpad.

### DIFF
--- a/etherpad/src/etherpad/control/pad/pad_control.js
+++ b/etherpad/src/etherpad/control/pad/pad_control.js
@@ -512,6 +512,7 @@ function render_reconnect() {
   var userId = (padutils.getPrefsCookieUserId() || undefined);
   var hasClientErrors = false;
   var uniqueId;
+  var errorMessage;
   try {
     var obj = fastJSON.parse(request.params.diagnosticInfo);
     uniqueId = obj.uniqueId;


### PR DESCRIPTION
Added "errorMessage" variable declaration to prevent "reconnect" calls causing a java exception
My instance of Etherpad at my place of work kept falling over after "reconnect" calls. This change has fixed the issue.
