### PR TITLE
Add TLS support to SMTP server configuration

### DIFF
--- a/infrastructure/net.appjet.ajstdlib/ajstdlib.scala
+++ b/infrastructure/net.appjet.ajstdlib/ajstdlib.scala
@@ -217,6 +217,7 @@ object email {
         val debug = false;
 
         val props = new Properties;
+	props.put("mail.smtp.starttls.enable", config.smtpStartTls);
         props.put("mail.smtp.host", config.smtpServerHost);
         props.put("mail.smtp.port", config.smtpServerPort.toString());
         if (config.smtpUser != "")

--- a/infrastructure/net.appjet.oui/config.scala
+++ b/infrastructure/net.appjet.oui/config.scala
@@ -208,6 +208,9 @@ object config {
   @ConfigParam("password for authentication to mail server. Default: no authentication.")
               { val argName = "password" } 
   def smtpPass = stringOrElse("smtpPass", "");
+  @ConfigParam("true or false to use starttls (TLS authentication) when connecting to mail server. Default: false.")
+              { val argName = "smtpStartTls" }
+  def smtpStartTls = stringOrElse("smtpStartTls", "false");
 
   // comet
   @ConfigParam("prefix for all comet requests. Required to use Comet system.")


### PR DESCRIPTION
Created configuration for SMTP server to connect to mail server with TLS authentication.  Configurable via smtpStartTls (options are true or false) in the etherpad.[...].properties file.  Default value is false.

I decided to include this as a configuration after finding a [hard-coded solution](http://top-frog.com/2010/03/15/enable-etherpad-to-send-email-via-gmail/) for using Gmail as the mail server, which required TLS authentication.
