### PR TITLE
Make sure the /var/log/etherpad directory always exists (issue #140)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -53,6 +53,7 @@ if ! getent passwd etherpad > /dev/null ; then
 fi
 
 # Give user the rights to write into the log & data directory
+mkdir -p "/var/log/etherpad"
 chown -R etherpad:etherpad "/var/log/etherpad"
 chown -R etherpad:etherpad "/usr/share/etherpad/etherpad/data"
 # Give user the rights do write everywhere, did not yet figure

--- a/debian/rules
+++ b/debian/rules
@@ -59,7 +59,6 @@ install: build
 	mv debian/etherpad/usr/share/etherpad/etherpad/etc debian/etherpad/etc/etherpad
 	ln -s /etc/etherpad debian/etherpad/usr/share/etherpad/etherpad/etc
 
-	mkdir -p debian/etherpad/var/log/etherpad
 	mkdir -p debian/etherpad/usr/share/lintian/overrides
 	cp debian/source/lintian-overrides debian/etherpad/usr/share/lintian/overrides/etherpad
 


### PR DESCRIPTION
Prior to this change, reconfiguring the package would delete the
/var/log/etherpad directory (see prerm file) and not recreate it
afterwards.
