### PR TITLE
Correct repo link at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # About Etherpad
 # Etherpad (this version) has been superseded by Etherpad Lite #
-Etherpad Lite is a simplier, faster, lighter solution for collaborative editing.  Please use that and develop on that as it is the active project. <http://github.com/pita/etherpad-lite>
+Etherpad Lite is a simplier, faster, lighter solution for collaborative editing.  Please use that and develop on that as it is the active project.
+<https://github.com/ether/etherpad-lite>
 
 EtherPad is a web-based realtime collaborative document editor.
 


### PR DESCRIPTION
Follow-up to #278.

Now that @pita's repository is deprecated,
link should be changed to point to the active repo.
